### PR TITLE
added example check with check phase for TS 5.5.x

### DIFF
--- a/src/eu/cqse/check/sample/SampleCheckUsingPhase.java
+++ b/src/eu/cqse/check/sample/SampleCheckUsingPhase.java
@@ -1,0 +1,75 @@
+package test.sample.check;
+
+import java.util.List;
+
+import org.conqat.lib.commons.collections.CollectionUtils;
+
+import eu.cqse.check.framework.core.Check;
+import eu.cqse.check.framework.core.CheckException;
+import eu.cqse.check.framework.core.CheckGroupNames;
+import eu.cqse.check.framework.core.CheckImplementationBase;
+import eu.cqse.check.framework.core.ECheckParameter;
+import eu.cqse.check.framework.core.EFindingEnablement;
+import eu.cqse.check.framework.core.phase.ECodeViewOption;
+import eu.cqse.check.framework.scanner.ELanguage;
+import eu.cqse.check.framework.shallowparser.SubTypeNames;
+import eu.cqse.check.framework.shallowparser.framework.EShallowEntityType;
+import eu.cqse.check.framework.shallowparser.framework.ShallowEntity;
+import eu.cqse.check.framework.shallowparser.framework.ShallowEntityTraversalUtils;
+
+/**
+ * This class implements an example custom check that demonstrates how to use
+ * custom check phases.
+ * 
+ * The check generates findings for class names that are equal to class names in
+ * other files. For example, if ClassA.java has an inner class myClass and
+ * ClassB.java also has an inner class myClass, this check generates two
+ * findings (on the myClass declarations).
+ * 
+ * By specifying an implementation of
+ * {@link eu.cqse.check.framework.core.phase.IGlobalExtractionPhase} in the
+ * phases property of the {@link Check} annotation, we specify that this check
+ * requires access to results from the given phase (and the phase must be
+ * executed before the check).
+ */
+@Check(name = "Sample Check with phase", description = "", groupName = CheckGroupNames.BAD_PRACTICE, defaultEnablement = EFindingEnablement.RED, languages = {
+		ELanguage.JAVA }, parameters = { ECheckParameter.ABSTRACT_SYNTAX_TREE }, phases = {
+				/*
+				 * This check requires that SamplePhase has been executed and accesses results
+				 * from that phase.
+				 */
+				SamplePhase.class })
+public class SampleCheckUsingPhase extends CheckImplementationBase {
+	@Override
+	public void execute() throws CheckException {
+		List<ShallowEntity> entities = context.getAbstractSyntaxTree(ECodeViewOption.FILTERED);
+		for (ShallowEntity entity : ShallowEntityTraversalUtils.listEntitiesOfType(entities, EShallowEntityType.TYPE)) {
+			if (!entity.getSubtype().equals(SubTypeNames.CLASS)) {
+				continue;
+			}
+			/*
+			 * Retrieve all declarations (including from this file) of classes that have the
+			 * same name as the current class. This accesses the results computed by
+			 * SamplePhase.
+			 * 
+			 * It also "registers" this check for this file for re-execution once the value
+			 * of <code>context
+			 * .accessPhaseInvertedResult(SamplePhase.class).apply(entity.getName())</code>
+			 * changes (e.g., because of changes in other files in future commits).
+			 */
+			List<SamplePhase.ClassDeclarationInfo> otherDeclarations = context
+					.accessPhaseInvertedResult(SamplePhase.class).apply(entity.getName());
+			// remove declarations from the current file from the list
+			otherDeclarations = CollectionUtils.filter(otherDeclarations,
+					declaration -> !declaration.getAdditionalInformation().uniformPath
+							.equals(context.getUniformPath()));
+			if (!otherDeclarations.isEmpty()) {
+				String otherUniformPaths = org.conqat.lib.commons.string.StringUtils.concat(
+						CollectionUtils.map(otherDeclarations, SamplePhase.ClassDeclarationInfo::getUniformPath), ", ");
+				// we could include the other uniform paths in the finding message, but that
+				// would make testing this example more complex
+				createFinding("found another type with same name", entity);
+			}
+		}
+	}
+}

--- a/src/eu/cqse/check/sample/SamplePhase.java
+++ b/src/eu/cqse/check/sample/SamplePhase.java
@@ -1,0 +1,135 @@
+package test.sample.check;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.conqat.lib.commons.collections.CollectionUtils;
+
+import eu.cqse.check.CheckTextRegionLocation;
+import eu.cqse.check.framework.core.CheckException;
+import eu.cqse.check.framework.core.phase.ECodeViewOption;
+import eu.cqse.check.framework.core.phase.IExtractedValue;
+import eu.cqse.check.framework.core.phase.IGlobalExtractionPhase;
+import eu.cqse.check.framework.core.phase.ITokenElementContext;
+import eu.cqse.check.framework.scanner.ELanguage;
+import eu.cqse.check.framework.scanner.IToken;
+import eu.cqse.check.framework.shallowparser.SubTypeNames;
+import eu.cqse.check.framework.shallowparser.framework.EShallowEntityType;
+import eu.cqse.check.framework.shallowparser.framework.ShallowEntity;
+import eu.cqse.check.framework.shallowparser.framework.ShallowEntityTraversalUtils;
+
+/**
+ * This custom check phase scans all java code files and extracts class
+ * declarations (including inner classes). The declarations are persisted in a
+ * teamscale-internal database for later access in a custom check.
+ * 
+ * The stored entries look like this:
+ * 
+ * <pre>
+ * "uniformPathOfFileA.java" -> "A" (ClassDeclarationInfo1)
+ * "uniformPathOfFileA.java" -> "inner" (ClassDeclarationInfo2)
+ * "uniformPathOfFileB.java" -> "B" (ClassDeclarationInfo3)
+ * "uniformPathOfFileB.java" -> "inner" (ClassDeclarationInfo4)
+ * </pre>
+ * 
+ * The information can be accessed "by uniform path" (returns all declaration
+ * objects for a given uniform path) or "by value" (returns all declaration
+ * objects for e.g., "inner"). For the second access pattern,
+ * {@link #needsAccessUniformPathByValue()} must be overwritten and must return
+ * true.
+ */
+public class SamplePhase implements IGlobalExtractionPhase<SamplePhase.ClassDeclarationInfo, CheckTextRegionLocation> {
+
+	@Override
+	public Set<ELanguage> getLanguages() {
+		// The phase should be executed for Java files only.
+		return Collections.singleton(ELanguage.JAVA);
+	}
+
+	@Override
+	public boolean needsAccessUniformPathByValue() {
+		/*
+		 * The checks accessing the results of this phase need to access "by value"
+		 * (e.g.,
+		 * <code>context.accessPhaseInvertedResult(SamplePhase.class).apply("inner")</
+		 * code>)
+		 */
+		return true;
+	}
+
+	@Override
+	public List<ClassDeclarationInfo> extract(ITokenElementContext element) throws CheckException {
+		List<ClassDeclarationInfo> results = new ArrayList<>();
+		List<ShallowEntity> entities = element.getAbstractSyntaxTree(ECodeViewOption.FILTERED);
+		// traverse all TYPE entities in code that is not filtered by text filters (can
+		// be configured in project settings)
+		for (ShallowEntity entity : ShallowEntityTraversalUtils.listEntitiesOfType(entities, EShallowEntityType.TYPE)) {
+			if (!entity.getSubtype().equals(SubTypeNames.CLASS)) {
+				// ignore non-class types (interfaces, etc.)
+				continue;
+			}
+			IToken startToken = entity.ownStartTokens().get(0);
+			IToken endToken = CollectionUtils.getLast(entity.ownStartTokens());
+			CheckTextRegionLocation location = new CheckTextRegionLocation(element.getUniformPath(),
+					startToken.getOffset(), endToken.getOffset(), startToken.getLineNumber(), endToken.getLineNumber());
+			// add a new ClassDeclarationInfo with the location of the current type
+			results.add(new ClassDeclarationInfo(entity.getName(), location));
+		}
+		return results;
+	}
+
+	@Override
+	public ClassDeclarationInfo createValue(String uniformPath, String value,
+			CheckTextRegionLocation additionalInformation) {
+		return new ClassDeclarationInfo(value, additionalInformation);
+	}
+
+	/**
+	 * "Transport object" that stores the name and location of a class declaration
+	 * (might declare an inner class).
+	 * 
+	 * The result of a check phase are a list of such {@link IExtractedValue}
+	 * objects which are stored associated with the currently analyzed file.
+	 */
+	public static class ClassDeclarationInfo implements IExtractedValue<CheckTextRegionLocation> {
+
+		/**
+		 * Simple name of the declared class.
+		 */
+		private final String className;
+
+		/**
+		 * Location of the class declaration (contains uniform path, line, and offset)
+		 */
+		private final CheckTextRegionLocation location;
+
+		public ClassDeclarationInfo(String className, CheckTextRegionLocation location) {
+			this.className = className;
+			this.location = location;
+		}
+
+		@Override
+		public CheckTextRegionLocation getAdditionalInformation() {
+			// You can store any (serializable) object that can't be encoded in the uniform
+			// path or in getValue() here. In this example, we need only
+			// the declaration's location.
+			return location;
+		}
+
+		@Override
+		public String getUniformPath() {
+			// this is the uniform path that can be used to access phase results in
+			// <code>context.accessPhaseResult(SamplePhase.class).apply("inner")</code>.
+			return location.uniformPath;
+		}
+
+		@Override
+		public String getValue() {
+			// this is the value that can be used to access phase results in
+			// <code>context.accessPhaseInvertedResult(SamplePhase.class).apply("inner")</code>.
+			return className;
+		}
+	}
+}

--- a/test-data/eu/cqse/check/sample/SampleCheckUsingPhase/Test1/Test1File1.java
+++ b/test-data/eu/cqse/check/sample/SampleCheckUsingPhase/Test1/Test1File1.java
@@ -1,0 +1,5 @@
+public class SampleCheckCode {
+	public class Inner {
+
+	}
+}

--- a/test-data/eu/cqse/check/sample/SampleCheckUsingPhase/Test1/Test1File1.java.expected
+++ b/test-data/eu/cqse/check/sample/SampleCheckUsingPhase/Test1/Test1File1.java.expected
@@ -1,0 +1,1 @@
+Offsets 32-55 (lines 2-4): found another type with same name

--- a/test-data/eu/cqse/check/sample/SampleCheckUsingPhase/Test1/Test1File2.java
+++ b/test-data/eu/cqse/check/sample/SampleCheckUsingPhase/Test1/Test1File2.java
@@ -1,0 +1,5 @@
+public class SampleCheckCode2 {
+	public class Inner {
+
+	}
+}

--- a/test-data/eu/cqse/check/sample/SampleCheckUsingPhase/Test2/Test2File1.java
+++ b/test-data/eu/cqse/check/sample/SampleCheckUsingPhase/Test2/Test2File1.java
@@ -1,0 +1,5 @@
+public class SampleCheckCode {
+	public class Inner {
+		
+	}
+}

--- a/test-data/eu/cqse/check/sample/SampleCheckUsingPhase/Test2/Test2File2.java
+++ b/test-data/eu/cqse/check/sample/SampleCheckUsingPhase/Test2/Test2File2.java
@@ -1,0 +1,5 @@
+public class SampleCheckCode2 {
+	public class Inner2 {
+		
+	}
+}


### PR DESCRIPTION
Example for a custom check that uses a check phase.
This enables implementing custom checks for incremental analysis based on global (instead of file-local) information.
This is compatible with Teamscale 5.5.x